### PR TITLE
Add sbt/setup-sbt@v1 to steward.yml

### DIFF
--- a/.github/workflows/steward.yml
+++ b/.github/workflows/steward.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: DIY Steward
     steps:
+      - uses: sbt/setup-sbt@v1
       - uses: actions/checkout@v4
           
       - name: Generate token


### PR DESCRIPTION
Fixes #3

Add sbt setup step to GitHub Actions workflow

* Add a new step to use `sbt/setup-sbt@v1` before the `actions/checkout@v4` step in `.github/workflows/steward.yml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/slick/slick-scala-steward/issues/3?shareId=072672b5-d954-49dd-ab0b-e00f6caf1d10).